### PR TITLE
fix nginx dynamic example regex in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ dynamicly. The following configuration must be added to the server section of
 each domain to be validated:
 
 ```
-location ~ "^/\.well-known/acme-challenge/(-_a-zA-Z0-9]+)$" {
+location ~ "^/\.well-known/acme-challenge/([-_a-zA-Z0-9]+)$" {
     default_type text/plain;
     return 200 "$1.ACCOUNT_THUMBPRINT";
 }


### PR DESCRIPTION
While testing this I came across this small typo in your nginx code example in README.md. Fixed so that it should actually work.
